### PR TITLE
Allow Laravel 13

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Validation rules that are used by the CamBuildr",
     "type": "library",
     "require": {
-        "laravel/framework": "^11.0|^12.0",
+        "laravel/framework": "^11.0|^12.0|^13.0",
         "php": "^8.2"
     },
     "license": "MIT",


### PR DESCRIPTION
Widens `laravel/framework` to `^11.0|^12.0|^13.0` for the Laravel 13 upgrade of cambuildr (MakersLab-ai/cambuildr#4935). No code changes.

After merge, please tag **8.1.0** so the app can move off the dev branch reference.